### PR TITLE
Resolve Feature/GEM-5 Validate Science Plan

### DIFF
--- a/gemini/backend/src/main/java/ict/mahidol/gemini/controller/SciencePlanController.java
+++ b/gemini/backend/src/main/java/ict/mahidol/gemini/controller/SciencePlanController.java
@@ -43,17 +43,6 @@ public class SciencePlanController {
     }
 
     @CrossOrigin
-    @PutMapping("/test")
-    public @ResponseBody
-    ResponseEntity<Map<String, String>> testSciencePlan(@RequestParam(value = "planId", required = false) Integer planId, HttpServletRequest request) 
-    {
-        Claims claims = (Claims) request.getAttribute("claims");
-        String role = claims.get("role", String.class);
-        
-        return sciencePlanServices.TestSciencePlan(role, planId);
-    }
-
-    @CrossOrigin
     @PutMapping("/submit")
     public ResponseEntity<Map<String, String>> submitSciencePlan(@RequestParam(value = "planId", required = false) Integer planId,
             HttpServletRequest request) {        
@@ -64,6 +53,17 @@ public class SciencePlanController {
         String role = claims.get("role", String.class);
 
         return sciencePlanServices.SubmitSciencePlan(username, role, planId);
+    }
+
+    @CrossOrigin
+    @PutMapping("/test")
+    public @ResponseBody
+    ResponseEntity<Map<String, String>> testSciencePlan(@RequestParam(value = "planId", required = false) Integer planId, HttpServletRequest request) 
+    {
+        Claims claims = (Claims) request.getAttribute("claims");
+        String role = claims.get("role", String.class);
+        
+        return sciencePlanServices.TestSciencePlan(role, planId);
     }
 
     @CrossOrigin

--- a/gemini/backend/src/main/java/ict/mahidol/gemini/services/SciencePlanServices.java
+++ b/gemini/backend/src/main/java/ict/mahidol/gemini/services/SciencePlanServices.java
@@ -67,31 +67,6 @@ public class SciencePlanServices {
         return ResponseEntity.ok(Map.of("message", "Science plan created successfully"));
     }
 
-    public @ResponseBody ResponseEntity<Map<String, String>> TestSciencePlan(String role, Integer planId)
-    {
-        if (!role.equals("astronomer")) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("message", "Access denied"));
-        }
-
-        if (planId == null) {
-            return ResponseEntity.badRequest().body(Map.of("message", "Missing/Invalid parameters"));
-        }
-
-        Optional<SciencePlan> sciencePlan = sciencePlanRepository.findById(planId);
-
-        if (!sciencePlan.isPresent()) {
-            return ResponseEntity.status(404)
-                    .body(Map.of("message", "No science plan record with id: " + planId + " found"));
-        }
-
-        if(!"SAVED".equals(sciencePlan.get().getPlanStatus())) return ResponseEntity.badRequest().body(Map.of("message", "This plan is already tested"));
-
-        sciencePlan.get().setPlanStatus("TESTED");
-        sciencePlanRepository.save(sciencePlan.get());
-
-        return ResponseEntity.ok(Map.of("message", "successfully tested science plan"));
-    }
-
     public ResponseEntity<Map<String, String>> SubmitSciencePlan(String username, String role, Integer planId)
     {
         // Handle unauthorized access
@@ -116,7 +91,7 @@ public class SciencePlanServices {
                     .body(Map.of("message", "No science plan record with id: " + planId + " found"));
         }
 
-        if(!"TESTED".equals(sciencePlan.get().getPlanStatus())) return ResponseEntity.badRequest().body(Map.of("message", "Unable to submit untested Science Plan/This plan is already submitted"));
+        if(!"SAVED".equals(sciencePlan.get().getPlanStatus())) return ResponseEntity.badRequest().body(Map.of("message", "This plan is already submitted"));
 
         // Update the science plan status and submitter
         sciencePlan.get().setPlanStatus("SUBMITTED");
@@ -126,6 +101,31 @@ public class SciencePlanServices {
         sciencePlanRepository.save(sciencePlan.get());
 
         return ResponseEntity.ok(Map.of("message", "Suceessfully submitted science plan."));
+    }
+
+    public @ResponseBody ResponseEntity<Map<String, String>> TestSciencePlan(String role, Integer planId)
+    {
+        if (!role.equals("astronomer")) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("message", "Access denied"));
+        }
+
+        if (planId == null) {
+            return ResponseEntity.badRequest().body(Map.of("message", "Missing/Invalid parameters"));
+        }
+
+        Optional<SciencePlan> sciencePlan = sciencePlanRepository.findById(planId);
+
+        if (!sciencePlan.isPresent()) {
+            return ResponseEntity.status(404)
+                    .body(Map.of("message", "No science plan record with id: " + planId + " found"));
+        }
+
+        if(!"SUBMITTED".equals(sciencePlan.get().getPlanStatus())) return ResponseEntity.badRequest().body(Map.of("message", "Unable to test unsubmitted Science Plan/This plan is already tested"));
+
+        sciencePlan.get().setPlanStatus("TESTED");
+        sciencePlanRepository.save(sciencePlan.get());
+
+        return ResponseEntity.ok(Map.of("message", "successfully tested science plan"));
     }
 
     public @ResponseBody ResponseEntity<Map<String, String>> ValidateSciencePlan(String role, Integer planId)
@@ -145,7 +145,7 @@ public class SciencePlanServices {
                     .body(Map.of("message", "No science plan record with id: " + planId + " found"));
         }
 
-        if(!"SUBMITTED".equals(sciencePlan.get().getPlanStatus())) return ResponseEntity.badRequest().body(Map.of("message", "Unable to validate unsubmitted Science Plan/This plan is already validated"));
+        if(!"TESTED".equals(sciencePlan.get().getPlanStatus())) return ResponseEntity.badRequest().body(Map.of("message", "Unable to validate untested Science Plan/This plan is already validated"));
 
         sciencePlan.get().setPlanStatus("VALIDATED");
         sciencePlanRepository.save(sciencePlan.get());


### PR DESCRIPTION
SciencePlanController.java
```java
@CrossOrigin
    @PutMapping("/validate")
    public @ResponseBody
    ResponseEntity<Map<String, String>> validateSciencePlan(@RequestParam(value = "planId", required = false) Integer planId, HttpServletRequest request) 
    {
        Claims claims = (Claims) request.getAttribute("claims");
        String role = claims.get("role", String.class);
        
        return sciencePlanServices.ValidateSciencePlan(role, planId);
    }
```
SciencePlanServices.java
```java
public @ResponseBody ResponseEntity<Map<String, String>> ValidateSciencePlan(String role, Integer planId)
    {
        if (!role.equals("scienceObserver")) {
            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("message", "Access denied"));
        }

        if (planId == null) {
            return ResponseEntity.badRequest().body(Map.of("message", "Missing/Invalid parameters"));
        }

        Optional<SciencePlan> sciencePlan = sciencePlanRepository.findById(planId);

        if (!sciencePlan.isPresent()) {
            return ResponseEntity.status(404)
                    .body(Map.of("message", "No science plan record with id: " + planId + " found"));
        }

        if(!"SUBMITTED".equals(sciencePlan.get().getPlanStatus())) return ResponseEntity.badRequest().body(Map.of("message", "Unable to validate unsubmitted Science Plan/This plan is already validated"));

        sciencePlan.get().setPlanStatus("VALIDATED");
        sciencePlanRepository.save(sciencePlan.get());

        return ResponseEntity.ok(Map.of("message", "successfully tested science plan"));
    }
```

Close #19 